### PR TITLE
Restrict crypton version to < 1.1

### DIFF
--- a/nova-cache.cabal
+++ b/nova-cache.cabal
@@ -53,7 +53,7 @@ library
     , base64-bytestring   >= 1.2 && < 1.3
     , bytestring          >= 0.11 && < 0.13
     , containers          >= 0.6 && < 0.8
-    , crypton             >= 1.0 && < 2
+    , crypton             >= 1.0 && < 1.1
     , directory           >= 1.3 && < 1.4
     , filepath            >= 1.4 && < 1.6
     , memory              >= 0.18 && < 1
@@ -106,7 +106,7 @@ test-suite nova-cache-test
       base                >= 4.16 && < 5
     , base64-bytestring   >= 1.2 && < 1.3
     , bytestring          >= 0.11 && < 0.13
-    , crypton             >= 1.0 && < 2
+    , crypton             >= 1.0 && < 1.1
     , directory           >= 1.3 && < 1.4
     , nova-cache
     , memory              >= 0.18 && < 1


### PR DESCRIPTION
Crypton changed the "memory" dependency to "ram" but Nova seems to otherwise depend on memory.