### PR TITLE
Fix narinfo fingerprint references, NAR length overflow, store-path hash validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install liblzma (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y liblzma-dev
+        run: sudo apt-get update && sudo apt-get install -y liblzma-dev
 
       - name: Build
         run: cabal build --ghc-options="-Werror" ${{ matrix.compression == false && '-f-compression' || '' }}

--- a/src/NovaCache/Base32.hs
+++ b/src/NovaCache/Base32.hs
@@ -6,6 +6,7 @@
 module NovaCache.Base32
   ( encode,
     decode,
+    isBase32Char,
   )
 where
 
@@ -48,6 +49,13 @@ asciiTableSize = 256
 -- | Sentinel value for characters outside the alphabet.
 invalidMarker :: Word8
 invalidMarker = 0xFF
+
+-- | Is a character part of the Nix base32 alphabet
+-- (@0123456789abcdfghijklmnpqrsvwxyz@)?  Used to validate store-path hashes.
+isBase32Char :: Char -> Bool
+isBase32Char c = case nixDecodeLut V.!? ord c of
+  Just v -> v /= invalidMarker
+  Nothing -> False
 
 -- | Bits per base32 character.
 bitsPerChar :: Int

--- a/src/NovaCache/NAR.hs
+++ b/src/NovaCache/NAR.hs
@@ -252,10 +252,20 @@ readStr :: NarParser ByteString
 readStr bs
   | BS.length bs < wordSize =
       Left "unexpected end of NAR: need 8 bytes for string length"
-  | totalLen > BS.length payload =
+  -- Compare the Word64 length to the remaining bytes BEFORE narrowing it to
+  -- Int: a hostile length above maxBound::Int would otherwise wrap negative
+  -- and slip past the totalLen check below.
+  | len > fromIntegral (BS.length payload) =
       Left
         ( "unexpected end of NAR: string length "
             ++ show len
+            ++ " exceeds remaining "
+            ++ show (BS.length payload)
+        )
+  | totalLen > BS.length payload =
+      Left
+        ( "unexpected end of NAR: padded string length "
+            ++ show totalLen
             ++ " exceeds remaining "
             ++ show (BS.length payload)
         )

--- a/src/NovaCache/Signing.hs
+++ b/src/NovaCache/Signing.hs
@@ -134,8 +134,13 @@ fingerprint ni =
       niStorePath ni,
       niNarHash ni,
       T.pack (show (niNarSize ni)),
-      T.intercalate referenceSep (niReferences ni)
+      T.intercalate referenceSep (map (storeDir <>) (niReferences ni))
     ]
+  where
+    -- References in a narinfo are basenames, but the fingerprint signs them as
+    -- full store paths (/nix/store/<hash>-<name>), matching C++ Nix.  The store
+    -- directory is the leading path of the (already absolute) niStorePath.
+    storeDir = T.dropWhileEnd (/= '/') (niStorePath ni)
 
 -- ---------------------------------------------------------------------------
 -- Signing and verification

--- a/src/NovaCache/StorePath.hs
+++ b/src/NovaCache/StorePath.hs
@@ -20,6 +20,7 @@ import Data.Char (isAlphaNum)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
+import NovaCache.Base32 (isBase32Char)
 
 -- ---------------------------------------------------------------------------
 -- Types
@@ -108,6 +109,8 @@ parseBaseName basename
       Left ("store path too short: " ++ T.unpack basename)
   | T.index basename storePathHashLen /= hashNameSeparator =
       Left ("expected '-' after hash in store path: " ++ T.unpack basename)
+  | not (T.all isBase32Char hashPart) =
+      Left ("invalid nix-base32 hash in store path: " ++ T.unpack hashPart)
   | T.null name =
       Left ("empty name in store path: " ++ T.unpack basename)
   | not (T.all validNameChar name) =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -424,6 +424,12 @@ testSigning =
               ok1 <- assertTrue "starts with 1;" (T.isPrefixOf "1;" fp)
               ok2 <- assertTrue "contains storePath" (T.isInfixOf "/nix/store/" fp)
               pure (ok1 && ok2),
+      test "fingerprint renders references as full store paths" $
+        let ni = mkTestNarInfo {NarInfo.niReferences = ["00000000000000000000000000000000-glibc-2.40"]}
+            fp = Signing.fingerprint ni
+         in assertTrue
+              "reference is a full /nix/store path in the fingerprint"
+              (T.isInfixOf "/nix/store/00000000000000000000000000000000-glibc-2.40" fp),
       test "parseSecretKey valid" $
         let keyBytes = BS.pack ([1 .. 32] ++ [33 .. 64])
             keyB64 = TE.decodeUtf8 (B64.encode keyBytes)


### PR DESCRIPTION
Fixes from the 2026-06-07 audit.

- **Signing**: the narinfo fingerprint now signs references as full store paths (`/nix/store/<hash>-<name>`), matching C++ Nix. It was emitting bare basenames, so it would reject every genuine cache.nixos.org signature on a path with references. The store directory is derived from the (absolute) `StorePath` field; adds a test covering the references case.
- **NAR**: bounds-check the `Word64` string length against the remaining buffer before narrowing it to `Int`, so a hostile length above `maxBound::Int` cannot wrap negative and slip past the check.
- **StorePath**: validate the hash against the nix-base32 alphabet (new `Base32.isBase32Char`), rejecting forged paths with out-of-alphabet characters.

Builds `-Werror` clean; tests, ormolu, and hlint all green.
