### PR TITLE
Harden the cache server and tighten narinfo parsing (0.4.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.4.0.0 — 2026-06-08
+
+### Breaking changes
+
+- **`NarInfo` drops the `niSystem` field** — `System` is not part of the Nix
+  narinfo wire format (Nix ignores unknown keys), so it is removed from the
+  exported record and `renderNarInfo` no longer emits a `System:` line.
+
+### Security
+
+- **API key required for writes** — the server refuses to start when
+  `CACHE_API_KEY` is unset, unless `--allow-open-writes` is passed explicitly,
+  so a missing environment variable can no longer leave the cache
+  world-writable.
+- **Streaming request-body cap** — request bodies are read in bounded chunks
+  with a running size check, so an unsized (chunked) upload can no longer
+  buffer past the 100 MB limit into memory before it is rejected.
+- **Stricter path validation** — `sanitizePath` now accepts only
+  `[A-Za-z0-9._+-]` names that are neither dotfiles nor Windows reserved device
+  names (`nul`, `con`, `com1`…), rejecting device access, alternate-data-stream
+  syntax, and the temporary-write prefix in addition to traversal.
+- **No internal detail in error responses** — store reads tolerate I/O errors
+  (treated as absence) and any uncaught handler exception maps to a plain 500,
+  so filesystem paths and error text are never returned to clients.
+
+### Bug fixes
+
+- **CRLF-tolerant narinfo parsing** — lines are split on the first colon with a
+  trailing carriage return stripped, so narinfo produced by other tools (or
+  with `\r\n` line endings) parses correctly instead of corrupting text fields
+  or rejecting valid integer fields.
+
 ## 0.3.2.1 — 2026-03-18
 
 - Replace partial `decodeUtf8` with total `decodeLatin1` in `Base64.encode`

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import Control.Exception (SomeException)
 import Data.Bifunctor (first)
 import Data.ByteArray (constEq)
 import qualified Data.ByteString as BS
@@ -16,12 +17,12 @@ import Network.Wai
     RequestBodyLength (..),
     Response,
     ResponseReceived,
+    getRequestBodyChunk,
     pathInfo,
     requestBodyLength,
     requestHeaders,
     requestMethod,
     responseLBS,
-    strictRequestBody,
   )
 import qualified Network.Wai.Handler.Warp as Warp
 import Network.Wai.Middleware.RequestLogger (logStdout)
@@ -30,6 +31,7 @@ import NovaCache.Signing (SecretKey, parseSecretKey, sign)
 import NovaCache.Store (FileStore, getCacheInfo, listNarInfoHashes, newFileStore, readNar, readNarInfo, writeNar, writeNarInfo)
 import NovaCache.Validate (validateNarInfo)
 import System.Environment (getArgs, lookupEnv)
+import System.Exit (exitFailure)
 import System.IO (hPutStrLn, stderr)
 import Text.Read (readMaybe)
 
@@ -91,6 +93,7 @@ main = do
       storeRoot = case args of
         ("--store" : s : _) -> s
         _ -> fromMaybe defaultStoreRoot storeEnv
+      allowOpenWrites = "--allow-open-writes" `elem` args
 
   store <- newFileStore storeRoot
   sigKey <- loadSigningKey sigKeyPath
@@ -110,7 +113,24 @@ main = do
   putStrLn ("signing: " ++ maybe "disabled" (const "enabled") sigKey)
   putStrLn ("write auth: " ++ maybe "disabled (open writes!)" (const "enabled") (cfgApiKey cfg))
   putStrLn ("request logging: " ++ if logRequests then "enabled" else "disabled (LOG_REQUESTS=0)")
-  Warp.run port (requestLogger (app cfg))
+
+  case cfgApiKey cfg of
+    Nothing
+      | not allowOpenWrites -> do
+          hPutStrLn stderr $
+            "FATAL: "
+              ++ apiKeyEnvVar
+              ++ " is not set — refusing to start with unauthenticated writes. "
+              ++ "Set "
+              ++ apiKeyEnvVar
+              ++ ", or pass --allow-open-writes to override (not recommended on a public host)."
+          exitFailure
+    _ -> pure ()
+
+  let settings =
+        Warp.setPort port $
+          Warp.setOnExceptionResponse onExceptionResponse Warp.defaultSettings
+  Warp.runSettings settings (requestLogger (app cfg))
 
 -- | Load a signing key from a file, if configured.
 loadSigningKey :: Maybe FilePath -> IO (Maybe SecretKey)
@@ -212,11 +232,20 @@ readBodyLimited :: Request -> IO (Maybe BS.ByteString)
 readBodyLimited req = case requestBodyLength req of
   KnownLength len
     | len > fromIntegral maxBodySize -> pure Nothing
-  _ -> do
-    body <- BL.toStrict <$> strictRequestBody req
-    if BS.length body > maxBodySize
-      then pure Nothing
-      else pure (Just body)
+  _ -> readChunks [] 0
+  where
+    -- Stream the body in chunks, aborting as soon as the running total
+    -- exceeds the cap — so an unsized (chunked) upload can never buffer
+    -- more than 'maxBodySize' into memory.
+    readChunks acc total = do
+      chunk <- getRequestBodyChunk req
+      if BS.null chunk
+        then pure (Just (BS.concat (reverse acc)))
+        else
+          let newTotal = total + BS.length chunk
+           in if newTotal > maxBodySize
+                then pure Nothing
+                else readChunks (chunk : acc) newTotal
 
 -- | Run an action with the limited request body, responding 413 if too large.
 withLimitedBody :: Request -> (Response -> IO ResponseReceived) -> (BS.ByteString -> IO ResponseReceived) -> IO ResponseReceived
@@ -312,6 +341,11 @@ notFound = responseLBS HTTP.status404 textHeaders "not found"
 -- | 400 Bad Request with a text error message.
 badRequest :: Text -> Response
 badRequest msg = responseLBS HTTP.status400 textHeaders (BL.fromStrict (TE.encodeUtf8 msg))
+
+-- | Map any uncaught handler exception to a generic 500, so internal error
+-- detail (filesystem paths, exception text) is never leaked to clients.
+onExceptionResponse :: SomeException -> Response
+onExceptionResponse _ = responseLBS HTTP.status500 textHeaders "internal server error"
 
 -- | Content-Type: text/plain headers.
 textHeaders :: HTTP.ResponseHeaders

--- a/nova-cache.cabal
+++ b/nova-cache.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               nova-cache
-version:            0.3.2.1
+version:            0.4.0.0
 synopsis:           Pure Nix binary cache protocol library
 description:
   A focused, minimal, pure-first library implementing the full Nix binary

--- a/src/NovaCache/NarInfo.hs
+++ b/src/NovaCache/NarInfo.hs
@@ -2,7 +2,7 @@
 --
 -- A @.narinfo@ file is a simple @Key: Value@ text format describing a
 -- store path in a binary cache. The format supports multiple @Sig@ lines
--- and optional fields for @Deriver@, @System@, and @CA@.
+-- and optional fields for @Deriver@ and @CA@.
 module NovaCache.NarInfo
   ( NarInfo (..),
     parseNarInfo,
@@ -11,7 +11,7 @@ module NovaCache.NarInfo
 where
 
 import Data.List (find)
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 
@@ -30,7 +30,6 @@ data NarInfo = NarInfo
     niNarSize :: !Integer,
     niReferences :: ![Text],
     niDeriver :: !(Maybe Text),
-    niSystem :: !(Maybe Text),
     niSigs :: ![Text],
     niCA :: !(Maybe Text)
   }
@@ -52,19 +51,18 @@ keyNarHash = "NarHash"
 keyNarSize = "NarSize"
 keyReferences = "References"
 
-keyDeriver, keySystem, keySig, keyCA :: Text
+keyDeriver, keySig, keyCA :: Text
 keyDeriver = "Deriver"
-keySystem = "System"
 keySig = "Sig"
 keyCA = "CA"
 
--- | Key-value separator in narinfo format.
+-- | Key-value separator used when rendering narinfo lines.
 kvSeparator :: Text
 kvSeparator = ": "
 
--- | Length of the key-value separator.
-kvSeparatorLen :: Int
-kvSeparatorLen = 2
+-- | Field delimiter used when parsing (Nix splits on the first colon).
+fieldColon :: Text
+fieldColon = ":"
 
 -- ---------------------------------------------------------------------------
 -- Parsing
@@ -92,7 +90,6 @@ parseNarInfo txt = do
         niNarSize = narSize,
         niReferences = parseRefs (lookupFirst keyReferences kvs),
         niDeriver = lookupFirst keyDeriver kvs,
-        niSystem = lookupFirst keySystem kvs,
         niSigs = lookupAll keySig kvs,
         niCA = lookupFirst keyCA kvs
       }
@@ -122,7 +119,6 @@ renderNarInfo ni =
       kv keyReferences (T.unwords (niReferences ni))
     ]
       ++ optionalKV keyDeriver (niDeriver ni)
-      ++ optionalKV keySystem (niSystem ni)
       ++ map (kv keySig) (niSigs ni)
       ++ optionalKV keyCA (niCA ni)
 
@@ -131,11 +127,18 @@ renderNarInfo ni =
 -- ---------------------------------------------------------------------------
 
 -- | Parse a single @Key: Value@ line.
+--
+-- Splits on the first colon (matching Nix), strips a single leading space
+-- from the value, and tolerates a trailing carriage return so CRLF-terminated
+-- narinfo from other tools parses correctly.
 parseLine :: Text -> Maybe (Text, Text)
-parseLine line = case T.breakOn kvSeparator line of
+parseLine rawLine = case T.breakOn fieldColon line of
   (_, rest)
     | T.null rest -> Nothing
-  (key, rest) -> Just (key, T.drop kvSeparatorLen rest)
+  (key, rest) -> Just (key, dropLeadingSpace (T.drop 1 rest))
+  where
+    line = T.dropWhileEnd (== '\r') rawLine
+    dropLeadingSpace value = fromMaybe value (T.stripPrefix " " value)
 
 -- | Render a key-value pair.
 kv :: Text -> Text -> Text

--- a/src/NovaCache/Store.hs
+++ b/src/NovaCache/Store.hs
@@ -19,9 +19,10 @@ module NovaCache.Store
   )
 where
 
-import Control.Exception (SomeException, catch, onException)
+import Control.Exception (IOException, SomeException, catch, onException)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
 import Data.Text (Text)
 import qualified Data.Text as T
 import System.Directory
@@ -159,19 +160,37 @@ getCacheInfo fs = (fsStoreDir fs, True, fsPriority fs)
 -- Path sanitization
 -- ---------------------------------------------------------------------------
 
--- | Validate a path component for safe filesystem use.
+-- | Validate a path component for safe filesystem use via a positive allowlist.
 --
--- Rejects components containing directory separators (@\/@, @\\@),
--- traversal sequences (@..@), or empty strings. Returns 'Just' the
--- sanitized 'FilePath' on success, 'Nothing' on rejection.
+-- Accepts only non-empty names of @[A-Za-z0-9._+-]@ that do not start with a
+-- dot and are not a Windows reserved device name. This rejects directory
+-- separators, @.@\/@..@ traversal, dotfiles (including the temp-write prefix),
+-- NUL bytes, alternate-data-stream (@name:stream@) syntax, and device names
+-- like @nul@ — so a client-supplied hash or NAR filename can never escape the
+-- store directory or resolve to a device, on any platform.
 sanitizePath :: Text -> Maybe FilePath
 sanitizePath txt
   | T.null txt = Nothing
-  | T.any isPathSeparator txt = Nothing
-  | txt == ".." = Nothing
+  | T.isPrefixOf "." txt = Nothing
+  | T.any (not . isSafeChar) txt = Nothing
+  | isReservedName txt = Nothing
   | otherwise = Just (T.unpack txt)
   where
-    isPathSeparator c = c == '/' || c == '\\'
+    isSafeChar c =
+      isAsciiLower c || isAsciiUpper c || isDigit c || c `elem` ("._-+" :: [Char])
+
+-- | Is the name a Windows reserved device (@con@, @prn@, @aux@, @nul@,
+-- @com1@-@com9@, @lpt1@-@lpt9@)? Matched case-insensitively on the portion
+-- before the first dot, since @nul.txt@ also opens the device. Enforced on
+-- every platform so a Windows-hosted cache is safe too.
+isReservedName :: Text -> Bool
+isReservedName txt = T.toLower (T.takeWhile (/= '.') txt) `elem` reservedNames
+  where
+    reservedNames =
+      ["con", "prn", "aux", "nul"]
+        ++ ["com" <> n | n <- digits]
+        ++ ["lpt" <> n | n <- digits]
+    digits = [T.pack (show n) | n <- [1 .. 9 :: Int]]
 
 -- ---------------------------------------------------------------------------
 -- Internal
@@ -205,9 +224,17 @@ ignoringExceptions action = action `catch` silenceException
     silenceException _ = pure ()
 
 -- | Read a file if it exists, returning 'Nothing' otherwise.
+--
+-- Any I/O error (bad permissions, a race with deletion, a name that slips
+-- through validation) is treated as absence rather than propagating and
+-- crashing the request handler.
 readIfExists :: FilePath -> IO (Maybe ByteString)
-readIfExists path = do
-  exists <- doesFileExist path
-  if exists
-    then Just <$> BS.readFile path
-    else pure Nothing
+readIfExists path = readExisting `catch` ignoreIOError
+  where
+    readExisting = do
+      exists <- doesFileExist path
+      if exists
+        then Just <$> BS.readFile path
+        else pure Nothing
+    ignoreIOError :: IOException -> IO (Maybe ByteString)
+    ignoreIOError _ = pure Nothing

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -330,7 +330,6 @@ sampleNarInfoText =
       "NarSize: 67890",
       "References: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-1.0 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-glibc-2.38",
       "Deriver: cccccccccccccccccccccccccccccccc-hello-1.0.drv",
-      "System: x86_64-linux",
       "Sig: cache.example.com:c2lnbmF0dXJl",
       "Sig: backup.example.com:YW5vdGhlcnNpZw=="
     ]
@@ -352,9 +351,8 @@ testNarInfo =
             ok5 <- assertEqual "narSize" 67890 (NarInfo.niNarSize ni)
             ok6 <- assertEqual "refs count" 2 (length (NarInfo.niReferences ni))
             ok7 <- assertEqual "deriver" (Just "cccccccccccccccccccccccccccccccc-hello-1.0.drv") (NarInfo.niDeriver ni)
-            ok8 <- assertEqual "system" (Just "x86_64-linux") (NarInfo.niSystem ni)
-            ok9 <- assertEqual "sigs count" 2 (length (NarInfo.niSigs ni))
-            pure (ok1 && ok2 && ok3 && ok4 && ok5 && ok6 && ok7 && ok8 && ok9),
+            ok8 <- assertEqual "sigs count" 2 (length (NarInfo.niSigs ni))
+            pure (ok1 && ok2 && ok3 && ok4 && ok5 && ok6 && ok7 && ok8),
       test "parse/render roundtrip" $
         case NarInfo.parseNarInfo sampleNarInfoText of
           Left err -> do
@@ -386,11 +384,10 @@ testNarInfo =
                 pure False
               Right ni -> do
                 ok1 <- assertEqual "deriver" Nothing (NarInfo.niDeriver ni)
-                ok2 <- assertEqual "system" Nothing (NarInfo.niSystem ni)
-                ok3 <- assertEqual "sigs" [] (NarInfo.niSigs ni)
-                ok4 <- assertEqual "ca" Nothing (NarInfo.niCA ni)
-                ok5 <- assertEqual "refs" [] (NarInfo.niReferences ni)
-                pure (ok1 && ok2 && ok3 && ok4 && ok5),
+                ok2 <- assertEqual "sigs" [] (NarInfo.niSigs ni)
+                ok3 <- assertEqual "ca" Nothing (NarInfo.niCA ni)
+                ok4 <- assertEqual "refs" [] (NarInfo.niReferences ni)
+                pure (ok1 && ok2 && ok3 && ok4),
       test "parse missing required key fails" $
         let incomplete = T.unlines ["StorePath: /nix/store/aaaa-test", "URL: nar/test.nar.xz"]
          in assertLeft "missing key" (NarInfo.parseNarInfo incomplete),
@@ -491,7 +488,6 @@ mkTestNarInfo =
       NarInfo.niNarSize = 200,
       NarInfo.niReferences = ["aaaa-hello-1.0"],
       NarInfo.niDeriver = Nothing,
-      NarInfo.niSystem = Nothing,
       NarInfo.niSigs = [],
       NarInfo.niCA = Nothing
     }
@@ -551,6 +547,10 @@ testFileStore =
         assertEqual "empty" Nothing (Store.sanitizePath ""),
       test "sanitizePath accepts valid hash" $
         assertEqual "valid" (Just "abc123def456") (Store.sanitizePath "abc123def456"),
+      test "sanitizePath rejects windows device name" $
+        assertEqual "device nul" Nothing (Store.sanitizePath "nul"),
+      test "sanitizePath rejects dotfile" $
+        assertEqual "dotfile" Nothing (Store.sanitizePath ".hidden"),
       test "read rejects traversal" $ do
         tmpDir <- createTestDir
         store <- Store.newFileStore tmpDir
@@ -611,7 +611,6 @@ mkValidNarInfo =
       NarInfo.niNarSize = 5,
       NarInfo.niReferences = ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-1.0"],
       NarInfo.niDeriver = Nothing,
-      NarInfo.niSystem = Nothing,
       NarInfo.niSigs = [],
       NarInfo.niCA = Nothing
     }


### PR DESCRIPTION
0.4.0.0 — server hardening + narinfo parsing robustness, with one breaking cleanup.

**Breaking:** `NarInfo` drops the `niSystem` field — `System` is not part of the Nix narinfo wire format (Nix ignores unknown keys).

**Hardening:**
- Require `CACHE_API_KEY` to start, unless `--allow-open-writes` is passed.
- Stream-cap request bodies in bounded chunks — a chunked upload can't buffer past the 100 MB limit.
- Positive `sanitizePath` allowlist: reject dotfiles, Windows device names, alternate-data-stream syntax, and traversal.
- Uncaught handler exceptions map to a generic 500; store reads tolerate I/O errors.

**Bug fix:** CRLF-tolerant narinfo parsing (split on first colon, strip trailing CR).

`-Werror` clean (lib + server), ormolu + hlint clean, all tests green.