### PR TITLE
CI: read the deploy host from a secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           chmod 600 ~/.ssh/oci_key
           cat >> ~/.ssh/config <<'SSHCFG'
           Host anv26
-            HostName anv26.novavero.ai
+            HostName ${{ secrets.OCI_HOST }}
             User ubuntu
             IdentityFile ~/.ssh/oci_key
             ProxyCommand cloudflared access ssh --hostname %h


### PR DESCRIPTION
Moves the OCI deploy hostname out of the public workflow into the `OCI_HOST` secret (`${{ secrets.OCI_HOST }}`).

Defense-in-depth / tidiness only — the box is reachable solely through Cloudflare Access with public port 22 closed, so the hostname was never the access control. CI-only change.

The deploy job only runs on push to main, so this hostname path is verified when the PR merges.