### PR TITLE
Deploy from the hosted arm64 runner instead of building on the box

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,15 +155,38 @@ jobs:
           cabal build all -f server --enable-tests
 
   # ---------------------------------------------------------------------------
-  # Deploy (Linux, main branch only)
+  # Deploy (main branch only): build on the hosted arm64 image, ship the
+  # binary.  anv26 is an Ampere box on the same Ubuntu 24.04, so the
+  # runner's glibc matches - and the production host deliberately carries
+  # no compiler toolchain.
   # ---------------------------------------------------------------------------
 
   deploy-server:
     name: Deploy Server
     needs: [build]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
+      - uses: actions/checkout@v6
+
+      - uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: '9.8'
+          cabal-version: 'latest'
+
+      - name: Cache Cabal store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: cabal-deploy-arm-${{ hashFiles('nova-cache.cabal') }}
+          restore-keys: cabal-deploy-arm-
+
+      - name: Build the server binary (arm64)
+        run: |
+          cabal build --flag server --ghc-options="-Wall -Werror"
+          cp "$(cabal list-bin --flag server nova-cache-server)" /tmp/nova-cache-server
+
       - name: Deploy to OCI
         env:
           OCI_SSH_KEY: ${{ secrets.OCI_SSH_KEY }}
@@ -173,12 +196,13 @@ jobs:
           TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
-          # Install cloudflared and reach the box through Cloudflare Access:
-          # its public port 22 is closed, so SSH is Access-only now.
+          # Install cloudflared (the arm64 asset - this runner is arm) and
+          # reach the box through Cloudflare Access: its public port 22 is
+          # closed, so SSH is Access-only now.
           # Pinned version + checksum: the deploy must not run whatever
           # binary "latest" serves on a given day.
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2026.7.1/cloudflared-linux-amd64 -o /tmp/cloudflared
-          echo "79a0ade7fc854f62c1aaef48424d9d979e8c2fcd039189d24db82b84cd146be1  /tmp/cloudflared" | sha256sum -c -
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2026.7.1/cloudflared-linux-arm64 -o /tmp/cloudflared
+          echo "18f2c9bfc7a67a971bd96f1a5a1935def3c1e52aa386626f1566f04e9b5478d6  /tmp/cloudflared" | sha256sum -c -
           sudo install -m 0755 /tmp/cloudflared /usr/local/bin/cloudflared
 
           mkdir -p ~/.ssh
@@ -218,6 +242,10 @@ jobs:
           EOF
 
           scp /tmp/nova-cache.service anv26:/tmp/nova-cache.service
+          # The binary rides the same Access tunnel as everything else; the
+          # service keeps serving during the transfer and stops only for
+          # the install below.
+          scp /tmp/nova-cache-server anv26:/tmp/nova-cache-server
 
           # Provision the API key as a root-only environment file.  The value
           # travels over stdin, so it appears in no command line, no log, and
@@ -226,16 +254,8 @@ jobs:
             "sudo sh -c 'umask 077; mkdir -p /etc/nix-cache; cat > /etc/nix-cache/env; chown root:root /etc/nix-cache/env; chmod 600 /etc/nix-cache/env'"
 
           ssh anv26 "\
-            source ~/.ghcup/env && \
-            cd ~/nova-cache && \
-            git pull && \
-            cabal update && \
-            cabal clean && \
-            cabal build --flag server --ghc-options='-Wall -Werror' && \
-            BINARY=\$(cabal list-bin --flag server nova-cache-server) && \
             sudo systemctl stop nova-cache.service && \
-            sudo cp \"\$BINARY\" /usr/local/bin/nova-cache-server && \
-            sudo chmod +x /usr/local/bin/nova-cache-server && \
+            sudo install -m 0755 /tmp/nova-cache-server /usr/local/bin/nova-cache-server && \
             sudo cp /tmp/nova-cache.service /etc/systemd/system/nova-cache.service && \
             sudo systemctl daemon-reload && \
             sudo systemctl start nova-cache.service && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - **The server refuses to start when `CACHE_API_KEY` normalizes to empty** (BOM or whitespace only - the copy-paste artifact). An empty armed key would authenticate an empty bearer token.
 - **The server refuses to start when a configured signing key fails to load.** It previously logged a warning and ran unsigned, persisting narinfos no trust anchor can verify - the same misconfiguration class the key parser now rejects, closed at the process boundary too.
 - **Configurable bind host: `--host` / `HOST`.** The default stays all interfaces, so existing deployments do not silently rebind.
-- The deploy workflow pins cloudflared by version and checksum instead of pulling `latest`.
+- The deploy workflow pins cloudflared by version and checksum instead of pulling `latest`, and builds the server on GitHub's hosted arm64 image (same Ubuntu as the production box), shipping the binary over the Access tunnel - the production host deliberately carries no compiler toolchain.
 - **The sdist ships `NOTICE`.** Apache-2.0 section 4(d) asks redistributions to carry it; the file existed in the repo but not in the released tarball.
 - **CI builds from the sdist in isolation**, so tree-vs-tarball divergences (files missing from the tarball, dev-only project settings) fail the pipeline instead of surfacing at install time. CI also compiles the server executable and test suites under `-Werror` on every platform.
 - Dropped the server executable's unused `crypton` dependency.


### PR DESCRIPTION
The 0.5.0.0 deploy failed with `ghc: could not execute: gcc`: the production box's hardening pass deliberately purged the compiler toolchain (gcc, libc6-dev, make), and the deploy still built the server on-box - a design from before hosted arm64 runners were available to public repos.

Build on `ubuntu-24.04-arm` instead - the same Ubuntu and glibc as the Ampere box, with the needed runtime libraries (libgmp10, libffi8, zlib1g, libnuma1) verified present on the host - and ship the binary over the existing Cloudflare Access tunnel, exactly as the unit file already travels. The service keeps serving during the transfer and restarts only for the install. cloudflared switches to the arm64 asset (the runner is arm now) under the same pinned version + checksum discipline.

Once this proves out over a few deploys, the box's now-unused 9 GB GHC toolchain (`~/.ghcup` + `~/.cabal`) can be retired, completing the no-toolchain-on-prod hardening.