### PR TITLE
CI: bump run-ormolu to v19 and pin the ormolu binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: haskell-actions/run-ormolu@v17
+      - uses: haskell-actions/run-ormolu@v19
         with:
+          # Pinned to the version the repo is formatted with: formatting
+          # is not stable across ormolu releases, and a floating version
+          # would fail CI on untouched code when upstream ships one.
+          # Upgrades bump this and the local binary together.
+          version: "0.7.7.0"
           pattern: |
             src/**/*.hs
             test/**/*.hs


### PR DESCRIPTION
Closes #23: the v17 wrapper declares the deprecated node20 runtime, so every run warns about the forced node24 migration; v19 declares node24. The ormolu binary is pinned to 0.7.7.0, the version the tree is formatted with - formatting is not stable across ormolu releases, so the floating default fails CI on untouched code whenever upstream ships one. Upgrades bump the pin and the local binary together.

The hlint pins stay at v2 until upstream ships a node24 release (tracked in #24). Mirrors Novavero-AI/nova-nix#59.