### PR TITLE
NAR: Windows-hazard entry names and the case-hack serialiser (0.6.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.0.0 - 2026-07-20
+
+- **NAR serialisation understands upstream's case-hack.** A case-folding store filesystem (Windows NTFS, default macOS APFS) cannot hold two sibling names differing only by case, so an extractor there materializes the collision with upstream's reversible `~nix~case~hack~<N>` suffix. `serialiseFromPath` now strips the suffix on those platforms - entries are emitted under their NAR names, ordered by them - so a hacked tree reproduces its original NAR bytes; two on-disk names stripping to the same entry fail loudly. New `serialiseFromPathWith` takes the mode explicitly (`CaseHack`, `defaultCaseHack`, `caseHackSuffix` exported); on other platforms a file legitimately named with the suffix still serialises verbatim. The platform-dependent default of `serialiseFromPath` is the behavior change behind the major bump.
+- **NAR entry names are checked against Windows resolution hazards.** `checkName` now also rejects a colon anywhere (drive prefix `C:evil`, alternate data stream `a:b`), Windows reserved device names (`nul`, `con`, `com1`..., matched on the portion before the first dot), and names ending in a dot or space (NTFS strips both, so the on-disk name would silently diverge from the NAR name). An extractor relying on `checkName` can no longer be steered outside its target directory or into a device by an archive entry name.
+- **`sanitizePath` rejects a trailing dot.** The store-key allowlist already excluded spaces and leading dots; a trailing dot slipped through and NTFS would strip it, landing the file under a different name than the one validated. The Windows-unsafe categories now live in one shared module, `NovaCache.SafeName`, used by both the store-key and NAR entry-name guards.
+
 ## 0.5.0.0 - 2026-07-12
 
 - **Signing: fingerprints sort and deduplicate references.** C++ Nix computes and verifies narinfo fingerprints over a sorted, deduplicated store-path set; signing in the narinfo's file order produced signatures real Nix clients reject while nova-cache's own `verify` (recomputing from the same order) passed and masked the divergence. References are now sorted by basename and deduplicated before signing.

--- a/nova-cache.cabal
+++ b/nova-cache.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               nova-cache
-version:            0.5.0.0
+version:            0.6.0.0
 synopsis:           Pure-first Nix binary cache protocol library
 description:
   A pure-first library implementing the Nix binary cache protocol -
@@ -35,6 +35,7 @@ library
     NovaCache.Hash
     NovaCache.NAR
     NovaCache.NarInfo
+    NovaCache.SafeName
     NovaCache.Server
     NovaCache.Signing
     NovaCache.Store

--- a/src/NovaCache/NAR.hs
+++ b/src/NovaCache/NAR.hs
@@ -17,6 +17,10 @@ module NovaCache.NAR
     deserialise,
     narHash,
     serialiseFromPath,
+    serialiseFromPathWith,
+    CaseHack (..),
+    defaultCaseHack,
+    caseHackSuffix,
   )
 where
 
@@ -32,6 +36,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Word (Word64)
 import qualified NovaCache.Hash as Hash
+import NovaCache.SafeName (hasTrailingDotOrSpace, isReservedDeviceName)
 import System.Directory
   ( doesDirectoryExist,
     doesFileExist,
@@ -42,6 +47,7 @@ import System.Directory
     pathIsSymbolicLink,
   )
 import System.FilePath ((</>))
+import qualified System.Info
 
 -- ---------------------------------------------------------------------------
 -- Types
@@ -256,9 +262,19 @@ parseDirectory = go Nothing []
       | T.null name = Left "empty NAR directory entry name"
       -- Backslash is a directory separator on Windows - this library's
       -- primary consumer - so a name like "..\out.exe" is as much a
-      -- traversal vector as one with '/'.
-      | name == "." || name == ".." || T.any (\c -> c == '/' || c == '\\' || c == '\0') name =
+      -- traversal vector as one with '/'.  A colon is a drive prefix
+      -- ("C:evil") or an NTFS alternate data stream ("a:b"), either of
+      -- which resolves the write somewhere other than a file of this name.
+      | name == "." || name == ".." || T.any (\c -> c == '/' || c == '\\' || c == '\0' || c == ':') name =
           Left ("unsafe NAR directory entry name: " ++ T.unpack name)
+      -- Windows-unsafe categories, shared with the store-key allowlist
+      -- (NovaCache.SafeName): a device name resolves to the device, and
+      -- NTFS strips a trailing dot or space so the on-disk name would
+      -- silently diverge from the NAR name.
+      | isReservedDeviceName name =
+          Left ("Windows reserved device name as NAR directory entry: " ++ T.unpack name)
+      | hasTrailingDotOrSpace name =
+          Left ("NAR directory entry name ends with a dot or space: " ++ T.unpack name)
       | Just p <- prev,
         name <= p =
           Left ("NAR directory entries not strictly increasing: " ++ T.unpack name)
@@ -344,32 +360,100 @@ narHash = Hash.hashBytes . serialise
 -- Filesystem to NarEntry (IO boundary)
 -- ---------------------------------------------------------------------------
 
--- | Walk a filesystem path and build a 'NarEntry'.
+-- | Whether the serialiser strips upstream's case-hack suffix from
+-- on-disk names.  A case-folding store filesystem cannot hold two
+-- sibling names differing only by case, so an extractor there
+-- materializes the second with a reversible suffix; serialisation must
+-- strip it for the tree to reproduce its original NAR bytes.
+data CaseHack = CaseHackEnabled | CaseHackDisabled
+  deriving (Eq, Show)
+
+-- | The platform default 'serialiseFromPath' uses: enabled where the
+-- store filesystem folds case (Windows NTFS, default macOS APFS),
+-- disabled elsewhere - a Linux file legitimately named with the suffix
+-- must serialise verbatim.  Matches upstream's use-case-hack defaults.
+defaultCaseHack :: CaseHack
+defaultCaseHack = case System.Info.os of
+  "mingw32" -> CaseHackEnabled
+  "darwin" -> CaseHackEnabled
+  _ -> CaseHackDisabled
+
+-- | Upstream's reversible collision suffix (its @caseHackSuffix@): an
+-- extractor appends @~nix~case~hack~<N>@ to a sibling whose name
+-- case-folds onto an earlier one, and serialisation strips from the
+-- suffix onward to recover the NAR name.
+caseHackSuffix :: Text
+caseHackSuffix = "~nix~case~hack~"
+
+-- | Walk a filesystem path and build a 'NarEntry' under
+-- 'defaultCaseHack'.
 --
--- This is the sole IO function in the module. It classifies each path
--- as symlink, directory, or regular file, then delegates to pure
--- constructors.
+-- This is the module's IO boundary. It classifies each path as symlink,
+-- directory, or regular file, then delegates to pure constructors.
 serialiseFromPath :: FilePath -> IO NarEntry
-serialiseFromPath path = do
+serialiseFromPath = serialiseFromPathWith defaultCaseHack
+
+-- | 'serialiseFromPath' with the case-hack mode explicit, for callers
+-- and tests that need behavior independent of the host platform.
+serialiseFromPathWith :: CaseHack -> FilePath -> IO NarEntry
+serialiseFromPathWith mode path = do
   isSym <- pathIsSymbolicLink path
   if isSym
     then NarSymlink . T.pack <$> getSymbolicLinkTarget path
     else do
       isDir <- doesDirectoryExist path
       if isDir
-        then buildDirectory path
+        then buildDirectory mode path
         else buildRegularFile path
 
--- | Build a directory entry by recursively walking children.
-buildDirectory :: FilePath -> IO NarEntry
-buildDirectory path = do
+-- | Build a directory entry by recursively walking children.  Under
+-- 'CaseHackEnabled', each on-disk name is stripped of the case-hack
+-- suffix and entries are ordered by the STRIPPED name (the NAR name);
+-- two on-disk names stripping to the same entry name fail loudly, as
+-- upstream's serialiser does - continuing would emit an archive with
+-- duplicate entries no parser accepts.
+buildDirectory :: CaseHack -> FilePath -> IO NarEntry
+buildDirectory mode path = do
   names <- sort <$> listDirectory path
-  entries <- traverse walkChild names
-  pure (NarDirectory entries)
+  case unhackedDirNames mode names of
+    Left (first, second) ->
+      fail
+        ( "serialiseFromPath: file name collision between '"
+            ++ (path </> first)
+            ++ "' and '"
+            ++ (path </> second)
+            ++ "' after case-hack stripping"
+        )
+    Right resolved -> do
+      entries <- traverse walkChild resolved
+      pure (NarDirectory entries)
   where
-    walkChild name = do
-      entry <- serialiseFromPath (path </> name)
-      pure (T.pack name, entry)
+    walkChild (entryName, diskName) = do
+      entry <- serialiseFromPathWith mode (path </> diskName)
+      pure (entryName, entry)
+
+-- | Resolve on-disk child names to (NAR entry name, on-disk name) pairs,
+-- ordered by entry name.  Under 'CaseHackDisabled' names pass through
+-- verbatim (already sorted by the caller).  Under 'CaseHackEnabled' the
+-- case-hack suffix is stripped; @Left@ carries the first pair of disk
+-- names whose stripped entry names coincide.
+unhackedDirNames :: CaseHack -> [FilePath] -> Either (FilePath, FilePath) [(Text, FilePath)]
+unhackedDirNames CaseHackDisabled names = Right [(T.pack name, name) | name <- names]
+unhackedDirNames CaseHackEnabled names =
+  detectCollision (sortBy (comparing fst) (map resolve names))
+  where
+    resolve diskName =
+      let (unhacked, rest) = T.breakOn caseHackSuffix (T.pack diskName)
+       in if T.null rest
+            then (T.pack diskName, diskName)
+            else (unhacked, diskName)
+    detectCollision resolved =
+      case [ (diskA, diskB)
+           | ((entryA, diskA), (entryB, diskB)) <- zip resolved (drop 1 resolved),
+             entryA == entryB
+           ] of
+        ((diskA, diskB) : _) -> Left (diskA, diskB)
+        [] -> Right resolved
 
 -- | Build a regular file entry, checking the executable bit.
 buildRegularFile :: FilePath -> IO NarEntry

--- a/src/NovaCache/SafeName.hs
+++ b/src/NovaCache/SafeName.hs
@@ -1,0 +1,34 @@
+-- | Windows-unsafe name categories, shared by the store-key allowlist
+-- ('NovaCache.Store.sanitizePath') and the NAR entry-name guard in
+-- "NovaCache.NAR": names Windows resolves to something other than an
+-- ordinary file of that exact spelling.  Both guards reject the same
+-- categories from one definition, so they cannot drift apart.
+module NovaCache.SafeName
+  ( isReservedDeviceName,
+    hasTrailingDotOrSpace,
+  )
+where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+
+-- | Is the name a Windows reserved device (@con@, @prn@, @aux@, @nul@,
+-- @com1@-@com9@, @lpt1@-@lpt9@)? Matched case-insensitively on the portion
+-- before the first dot, since @nul.txt@ also opens the device. Enforced on
+-- every platform so a Windows-hosted consumer is safe too.
+isReservedDeviceName :: Text -> Bool
+isReservedDeviceName txt = T.toLower (T.takeWhile (/= '.') txt) `elem` reservedNames
+  where
+    reservedNames =
+      ["con", "prn", "aux", "nul"]
+        ++ ["com" <> n | n <- digits]
+        ++ ["lpt" <> n | n <- digits]
+    digits = [T.pack (show n) | n <- [1 .. 9 :: Int]]
+
+-- | Does the name end with a dot or a space?  NTFS strips both at
+-- create time, so the on-disk name silently diverges from the requested
+-- one and the materialized tree no longer matches what named it.
+hasTrailingDotOrSpace :: Text -> Bool
+hasTrailingDotOrSpace name = case T.unsnoc name of
+  Just (_, end) -> end == '.' || end == ' '
+  Nothing -> False

--- a/src/NovaCache/Store.hs
+++ b/src/NovaCache/Store.hs
@@ -29,6 +29,7 @@ import qualified Data.ByteString as BS
 import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
 import Data.Text (Text)
 import qualified Data.Text as T
+import NovaCache.SafeName (hasTrailingDotOrSpace, isReservedDeviceName)
 import System.Directory
   ( createDirectoryIfMissing,
     doesFileExist,
@@ -234,34 +235,25 @@ getCacheInfo fs =
 -- | Validate a path component for safe filesystem use via a positive allowlist.
 --
 -- Accepts only non-empty names of @[A-Za-z0-9._+-]@ that do not start with a
--- dot and are not a Windows reserved device name. This rejects directory
+-- dot, do not end with a dot (NTFS strips it, silently renaming the file),
+-- and are not a Windows reserved device name. This rejects directory
 -- separators, @.@\/@..@ traversal, dotfiles (including the temp-write prefix),
 -- NUL bytes, alternate-data-stream (@name:stream@) syntax, and device names
 -- like @nul@ - so a client-supplied hash or NAR filename can never escape the
--- store directory or resolve to a device, on any platform.
+-- store directory, resolve to a device, or land under a different name, on
+-- any platform.  The Windows-specific categories are shared with the NAR
+-- entry-name guard via "NovaCache.SafeName".
 sanitizePath :: Text -> Maybe FilePath
 sanitizePath txt
   | T.null txt = Nothing
   | T.isPrefixOf "." txt = Nothing
   | T.any (not . isSafeChar) txt = Nothing
-  | isReservedName txt = Nothing
+  | isReservedDeviceName txt = Nothing
+  | hasTrailingDotOrSpace txt = Nothing
   | otherwise = Just (T.unpack txt)
   where
     isSafeChar c =
       isAsciiLower c || isAsciiUpper c || isDigit c || c `elem` ("._-+" :: [Char])
-
--- | Is the name a Windows reserved device (@con@, @prn@, @aux@, @nul@,
--- @com1@-@com9@, @lpt1@-@lpt9@)? Matched case-insensitively on the portion
--- before the first dot, since @nul.txt@ also opens the device. Enforced on
--- every platform so a Windows-hosted cache is safe too.
-isReservedName :: Text -> Bool
-isReservedName txt = T.toLower (T.takeWhile (/= '.') txt) `elem` reservedNames
-  where
-    reservedNames =
-      ["con", "prn", "aux", "nul"]
-        ++ ["com" <> n | n <- digits]
-        ++ ["lpt" <> n | n <- digits]
-    digits = [T.pack (show n) | n <- [1 .. 9 :: Int]]
 
 -- ---------------------------------------------------------------------------
 -- Internal

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -363,8 +363,62 @@ testNAR =
         let valid = NAR.serialise (NAR.NarRegular False "x")
          in assertLeft "trailing bytes" (NAR.deserialise (valid <> "junk1234")),
       test "nonzero string padding rejected" $
-        assertLeft "nonzero padding" (NAR.deserialise badPaddingNar)
+        assertLeft "nonzero padding" (NAR.deserialise badPaddingNar),
+      -- Windows resolves these names to something other than a file of
+      -- this spelling (drive/stream colon, device, NTFS dot/space strip).
+      test "Windows-hazard entry names rejected" $
+        let evil name = NAR.serialise (NAR.NarDirectory [(name, NAR.NarRegular False "x")])
+            names = ["C:evil", "a:b", "nul", "NUL", "com1", "nul.txt", "foo.", "foo "]
+            rejected bytes = either (const True) (const False) (NAR.deserialise bytes)
+         in assertTrue "all hazard names rejected" (all (rejected . evil) names),
+      test "near-miss names still parse" $
+        let plain name = NAR.serialise (NAR.NarDirectory [(name, NAR.NarRegular False "x")])
+            names = ["nul2", "com10", "conx", "foo.bar", "a.b.c", "lpt0"]
+            accepted bytes = either (const False) (const True) (NAR.deserialise bytes)
+         in assertTrue "all near-miss names accepted" (all (accepted . plain) names),
+      -- The case-hack strip: a tree materialized with upstream's
+      -- collision suffix serialises back under its NAR names.
+      test "serialiseFromPathWith strips the case-hack suffix" $ do
+        dir <- caseHackFixture "nova-cache-test-casehack"
+        BS.writeFile (dir <> "/Foo") "upper"
+        BS.writeFile (dir <> "/foo~nix~case~hack~1") "lower"
+        entry <- NAR.serialiseFromPathWith NAR.CaseHackEnabled dir
+        removeDirectoryRecursive dir
+        let expected =
+              NAR.NarDirectory
+                [ ("Foo", NAR.NarRegular False "upper"),
+                  ("foo", NAR.NarRegular False "lower")
+                ]
+        roundTrip <- assertRight "stripped tree reparses" expected (NAR.deserialise (NAR.serialise entry))
+        pure (entry == expected && roundTrip),
+      test "serialiseFromPathWith keeps the suffix verbatim when disabled" $ do
+        dir <- caseHackFixture "nova-cache-test-casehack-off"
+        BS.writeFile (dir <> "/foo~nix~case~hack~1") "kept"
+        entry <- NAR.serialiseFromPathWith NAR.CaseHackDisabled dir
+        removeDirectoryRecursive dir
+        assertEqual
+          "verbatim name"
+          (NAR.NarDirectory [("foo~nix~case~hack~1", NAR.NarRegular False "kept")])
+          entry,
+      test "serialiseFromPathWith fails loudly on an unhack collision" $ do
+        dir <- caseHackFixture "nova-cache-test-casehack-clash"
+        BS.writeFile (dir <> "/foo") "plain"
+        BS.writeFile (dir <> "/foo~nix~case~hack~1") "hacked"
+        outcome <- try (NAR.serialiseFromPathWith NAR.CaseHackEnabled dir)
+        removeDirectoryRecursive dir
+        pure $ case (outcome :: Either SomeException NAR.NarEntry) of
+          Left _ -> True
+          Right _ -> False
     ]
+
+-- | A fresh, empty fixture directory under the system temp dir.
+caseHackFixture :: String -> IO FilePath
+caseHackFixture name = do
+  tmpBase <- getTemporaryDirectory
+  let dir = tmpBase <> "/" <> name
+  _ <- try (removeDirectoryRecursive dir) :: IO (Either SomeException ())
+  createDirectory dir
+  pure dir
 
 -- | Encode one NAR wire string with a chosen padding byte.  The spec
 -- demands zero padding, so a nonzero byte builds archives the parser
@@ -759,6 +813,10 @@ testFileStore =
         assertEqual "device nul" Nothing (Store.sanitizePath "nul"),
       test "sanitizePath rejects dotfile" $
         assertEqual "dotfile" Nothing (Store.sanitizePath ".hidden"),
+      test "sanitizePath rejects a trailing dot" $
+        assertEqual "trailing dot" Nothing (Store.sanitizePath "foo."),
+      test "sanitizePath keeps interior dots valid" $
+        assertEqual "interior dots" (Just "foo.nar.xz") (Store.sanitizePath "foo.nar.xz"),
       test "read rejects traversal" $ do
         tmpDir <- createTestDir
         store <- Store.newFileStore tmpDir


### PR DESCRIPTION
Closes #17; the serialiser half of Novavero-AI/nova-nix#67. Released as 0.6.0.0 (the platform-dependent default of serialiseFromPath is the behavior change behind the major bump).

**checkName gains the Windows resolution hazards (#17).** The NAR directory-entry guard now also rejects: a colon anywhere (drive prefix C:evil, alternate data stream a:b), Windows reserved device names (nul, con, com1..., matched case-insensitively on the portion before the first dot), and names ending in a dot or space (NTFS strips both at create time, so the on-disk name would silently diverge from the NAR name and the materialized tree from its hash). An extractor relying on checkName can no longer be steered outside its target directory or into a device by an entry name. Near-miss names (nul2, com10, foo.bar) stay accepted, pinned by tests.

**One shared definition for the shared categories.** The device-name and trailing-dot/space rules move to a new module, NovaCache.SafeName, used by both checkName and the store-key allowlist - the two guards cannot drift apart. In the move, sanitizePath picks up the trailing-dot rejection it was missing (its charset allows interior dots, and only the leading position was checked).

**The case-hack, serialiser side.** A case-folding store filesystem (Windows NTFS, default macOS APFS) cannot hold two sibling names differing only by case; an extractor there materializes the collision with upstream's reversible ~nix~case~hack~N suffix. serialiseFromPath now strips the suffix on those platforms and orders entries by the stripped NAR name, so a hacked tree reproduces its original NAR byte-for-byte; two on-disk names stripping to the same entry fail loudly, as upstream's serialiser does. serialiseFromPathWith takes the mode explicitly (CaseHack, defaultCaseHack, caseHackSuffix exported - the extractor side in nova-nix consumes the same constant), and on non-folding platforms a file legitimately named with the suffix still serialises verbatim.

The extractor half (applying the suffix on collision instead of refusing) lands in nova-nix once this releases; its on-disk hash recheck (nova-nix PR #66) then verifies the full round trip.

cabal test passes, -Werror build (server flag on) clean, ormolu and hlint clean, cabal check and sdist clean.
