### PR TITLE
Toolchain: GHC 9.14.1 (the first GHC LTS), ormolu 0.9.0.0, hlint 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: haskell-actions/hlint-setup@v2
         with:
-          version: '3.8'
+          version: '3.10'
       - uses: haskell-actions/hlint-run@v2
         with:
           path: '["src/", "test/", "exe/"]'
@@ -55,13 +55,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: haskell-actions/run-ormolu@v19
+      - uses: haskell-actions/run-ormolu@v21
         with:
           # Pinned to the version the repo is formatted with: formatting
           # is not stable across ormolu releases, and a floating version
           # would fail CI on untouched code when upstream ships one.
           # Upgrades bump this and the local binary together.
-          version: "0.7.7.0"
+          version: "0.9.0.0"
           pattern: |
             src/**/*.hs
             test/**/*.hs
@@ -91,7 +91,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: '9.8'
+          ghc-version: '9.14.1'
           cabal-version: 'latest'
 
       - name: Cache Cabal store
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: haskell-actions/setup@v2
         with:
-          ghc-version: '9.8'
+          ghc-version: '9.14.1'
           cabal-version: 'latest'
       - run: cabal check
 
@@ -142,7 +142,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: '9.8'
+          ghc-version: '9.14.1'
           cabal-version: 'latest'
 
       - name: Cache Cabal store
@@ -177,7 +177,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: '9.8'
+          ghc-version: '9.14.1'
           cabal-version: 'latest'
 
       - name: Cache Cabal store

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
           echo "Set version to $TAG_VERSION"
       - uses: haskell-actions/setup@v2
         with:
-          ghc-version: '9.8'
+          ghc-version: '9.14.1'
           cabal-version: 'latest'
       - run: cabal sdist
       - name: Upload to Hackage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Toolchain: GHC 9.14.1 (the first GHC LTS release)** - CI, the deploy and release pipelines, and the README badge move from GHC 9.8.4 to 9.14.1, matching nova-nix. GHC 9.14 opens GHC's new LTS scheme (a minimum of two years of bugfix releases), and under that scheme every earlier series stops receiving fixes, so no version in between had a future. Dependency bounds already admitted the newer compiler and the full set resolves on it. The project targets the LTS alone: base >= 4.22, and foldl' comes from the Prelude, so its one redundant Data.List import is gone.
+
 ## 0.7.0.0 - 2026-07-21
 
 - **NAR entry names and symlink targets are byte strings.** The format imposes no text encoding on either, and upstream carries both verbatim; decoding them as UTF-8 at parse rejected archives real Nix accepts. `NarEntry` now carries `ByteString` for directory entry names and symlink targets (the breaking change behind the major bump), the parser stops decoding, and entry order is defined bytewise. For names both representations accept - valid UTF-8 - code-point order and byte order coincide, so previously-valid archives keep their exact bytes and hashes. The `checkName` rejection categories apply unchanged to the byte form; they are ASCII-structural, so they now also catch hazards inside names that do not decode (a `nul.` device stem followed by undecodable bytes used to fail as bad UTF-8 and still fails - for the real reason).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to nova-cache
 
-Thanks for your interest. Issues and pull requests are welcome.
+nova-cache is a project of Novavero AI Inc. Thanks for your interest - issues
+and pull requests are welcome.
 
 ## Ground rules
 
@@ -12,8 +13,8 @@ Thanks for your interest. Issues and pull requests are welcome.
 
 nova-cache is licensed under Apache-2.0. Per Section 5 of the license, any
 contribution intentionally submitted for inclusion in this project is licensed
-under Apache-2.0, without additional terms or conditions, with Novavero AI Inc.
-as the project licensor. If you do not agree with this, do not submit the
-contribution. Submit only work you have the right to license.
+under Apache-2.0, without additional terms or conditions. You keep the
+copyright to your work. Submit only work you have the right to license.
 
-This keeps the project's licensing simple and its future flexible for everyone.
+This is the standard inbound=outbound arrangement: you contribute under the
+same terms you received the project under, nothing more.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 nova-cache
-Copyright 2026 Novavero AI Inc.
+Copyright 2026 Novavero AI Inc. and contributors
 
 This product is licensed under the Apache License, Version 2.0.
 A copy of the License is provided in the LICENSE file, or at

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![CI](https://github.com/Novavero-AI/nova-cache/actions/workflows/ci.yml/badge.svg)](https://github.com/Novavero-AI/nova-cache/actions/workflows/ci.yml)
 [![Hackage](https://img.shields.io/hackage/v/nova-cache.svg)](https://hackage.haskell.org/package/nova-cache)
-![GHC](https://img.shields.io/badge/GHC-9.8-purple)
+![GHC](https://img.shields.io/badge/GHC-9.14-purple)
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)
 
 </div>
@@ -99,7 +99,7 @@ cabal build
 cabal test
 ```
 
-Optional flag: `--flag server` builds the cache server. Requires GHC 9.8+ and cabal-install 3.10+.
+Optional flag: `--flag server` builds the cache server. Requires GHC 9.14+ and cabal-install 3.10+.
 
 ---
 

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -135,9 +135,9 @@ main = do
     _ -> pure ()
 
   let settings =
-        Warp.setHost (fromString bindHost) $
-          Warp.setPort port $
-            Warp.setOnExceptionResponse onExceptionResponse Warp.defaultSettings
+        Warp.setHost (fromString bindHost)
+          $ Warp.setPort port
+          $ Warp.setOnExceptionResponse onExceptionResponse Warp.defaultSettings
   Warp.runSettings settings (requestLogger (cacheApp cfg))
 
 -- ---------------------------------------------------------------------------

--- a/nova-cache.cabal
+++ b/nova-cache.cabal
@@ -17,7 +17,7 @@ bug-reports:        https://github.com/Novavero-AI/nova-cache/issues
 category:           Nix, Distribution
 stability:          experimental
 build-type:         Simple
-tested-with:        GHC == 9.8.4
+tested-with:        GHC == 9.14.1
 extra-doc-files:
     CHANGELOG.md
     NOTICE
@@ -43,7 +43,7 @@ library
     NovaCache.Validate
 
   build-depends:
-      base                >= 4.16 && < 5
+      base                >= 4.22 && < 5
     , base64-bytestring   >= 1.2 && < 1.3
     , bytestring          >= 0.11 && < 0.13
     , containers          >= 0.6 && < 0.9
@@ -81,7 +81,7 @@ executable nova-cache-server
   ghc-options:      -Wall -Wcompat -threaded -rtsopts
 
   build-depends:
-      base                >= 4.16 && < 5
+      base                >= 4.22 && < 5
     , bytestring          >= 0.11 && < 0.13
     , nova-cache
     , http-types          >= 0.12 && < 0.13
@@ -100,7 +100,7 @@ test-suite nova-cache-test
   ghc-options:      -Wall -Wcompat
 
   build-depends:
-      base                >= 4.16 && < 5
+      base                >= 4.22 && < 5
     , base64-bytestring   >= 1.2 && < 1.3
     , bytestring          >= 0.11 && < 0.13
     , crypton             >= 1.1 && < 2

--- a/src/NovaCache/NarInfo.hs
+++ b/src/NovaCache/NarInfo.hs
@@ -10,7 +10,6 @@ module NovaCache.NarInfo
   )
 where
 
-import Data.List (foldl')
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T


### PR DESCRIPTION
The full nova-nix #97+#98+#99 treatment in one pass, bringing nova-cache to the same toolchain.

- **GHC 9.14.1**: CI (including the arm64 deploy job) and the release pipeline move from 9.8.4 to 9.14.1; README badge and requires-line updated; `tested-with: GHC == 9.14.1`; `base >= 4.22` in all three stanzas. `foldl'` comes from the Prelude now, so the one redundant `Data.List` import is gone. Unlike nova-nix, no `-Wno-pattern-namespace-specifier` is needed: nova-cache uses no pattern synonyms.
- **Lint pins**: hlint 3.8 -> 3.10, run-ormolu v19 -> v21 with ormolu 0.7.7.0 -> 0.9.0.0 (pinned to the version the repo is formatted with, as before). The 0.9 reformat touches `exe/Main.hs` only.
- **CONTRIBUTING/NOTICE**: inbound=outbound wording and project credit up top; NOTICE gains "and contributors" (ports nova-nix #99, which never made it over).

Verified locally on GHC 9.14.1: `cabal build all -f server --enable-tests --ghc-options=-Werror` clean; 9/9 test groups pass; `cabal check` clean; hlint 3.10 no hints; ASCII check clean.

Merging deploys the 9.14.1-built server binary to the cache box (expected).
