### PR TITLE
CI: deploys clean their /tmp staging copies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,7 @@ jobs:
             sudo systemctl stop nova-cache.service && \
             sudo install -m 0755 /tmp/nova-cache-server /usr/local/bin/nova-cache-server && \
             sudo cp /tmp/nova-cache.service /etc/systemd/system/nova-cache.service && \
+            rm -f /tmp/nova-cache-server /tmp/nova-cache.service && \
             sudo systemctl daemon-reload && \
             sudo systemctl start nova-cache.service && \
             sudo systemctl status nova-cache.service --no-pager"


### PR DESCRIPTION
The deploy job scp's `nova-cache-server` and the unit file to `/tmp` on the box, installs both, and leaves the copies behind - every deploy parks ~55MB of residue until the next one overwrites it (found during today's box audit). Remove them right after `install` and `cp` consume them, keeping `systemctl status` as the final verification step.

Self-proving: the first deploy that runs with this change leaves `/tmp` clean on the box without anyone touching it.
