### PR TITLE
Toolchain: pin the Hackage index-state

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+packages: .
+
+-- Pin the dependency universe: local, CI, and contributor builds resolve
+-- identical versions regardless of when they last ran cabal update.  Bump
+-- deliberately - a fresh timestamp - when adopting new releases.
+index-state: 2026-08-20T01:41:58Z


### PR DESCRIPTION
The exact mirror of nova-nix #103, which never made it across when #29 ported the toolchain work: with the pin, local, CI, and contributor builds resolve identical versions regardless of when anyone last ran `cabal update`, so a Hackage upload cannot silently change what a previously-green tree resolves.

Pinned to `2026-08-20T01:41:58Z` - the same timestamp as nova-nix's pin, and the exact index head every green build today already resolved against, so the value is pre-proven. `cabal.project` is not included in the sdist, so the published package is unaffected.

Gate green locally with both flags under the pin. Bump deliberately (a fresh timestamp) when adopting new releases - the first customer is the post-0.8.0.0 advance, in lockstep with nova-nix's.