### PR TITLE
CI: upload documentation to Hackage with each release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Docs
+
+# Re-upload documentation for an already-published release.  The publish
+# workflow uploads docs for new releases; this exists for versions that
+# shipped before it did (0.8.0.0), or if a doc upload ever needs redoing.
+# Hackage's own doc builder runs an older GHC than the base floor admits,
+# so maintainer-built docs are the only docs these releases get.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to upload documentation for (e.g. v0.8.0.0)
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  docs:
+    name: Upload docs to Hackage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
+
+      # Same tag-is-the-version rule as the publish workflow, for tags
+      # whose tree predates the in-repo version bump.
+      - name: Set version from tag
+        run: |
+          TAG_VERSION="${{ inputs.tag }}"
+          TAG_VERSION=${TAG_VERSION#v}
+          sed -i "s/^version:.*/version:            $TAG_VERSION/" nova-cache.cabal
+
+      - uses: haskell-actions/setup@v2
+        with:
+          ghc-version: '9.14.1'
+          cabal-version: 'latest'
+
+      - name: Build documentation
+        run: cabal haddock --haddock-for-hackage -f xz
+
+      - name: Upload documentation to Hackage
+        env:
+          HACKAGE_TOKEN: ${{ secrets.HACKAGE_TOKEN }}
+        run: |
+          VERSION="${{ inputs.tag }}"
+          VERSION=${VERSION#v}
+          curl -X PUT --fail --silent --show-error \
+            --header "Authorization: X-ApiKey ${HACKAGE_TOKEN}" \
+            --header "Content-Type: application/x-tar" \
+            --header "Content-Encoding: gzip" \
+            --data-binary "@dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" \
+            "https://hackage.haskell.org/package/nova-cache-${VERSION}/docs"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,3 +42,25 @@ jobs:
             https://hackage.haskell.org/packages/
         env:
           HACKAGE_TOKEN: ${{ secrets.HACKAGE_TOKEN }}
+
+      # Maintainer-built documentation, permanently - not a stopgap for
+      # Hackage's doc builder lagging GHC (today it carries 9.8 against a
+      # base >= 4.22 floor, so it cannot even plan the build).  Even a
+      # caught-up builder compiles default flags only and would silently
+      # omit the flag-gated NovaCache.Xz; building here documents every
+      # module with the same pinned toolchain the release was verified
+      # on, and the docs land with the release instead of on the
+      # builder's schedule.
+      - name: Build documentation
+        run: cabal haddock --haddock-for-hackage -f xz
+      - name: Upload documentation to Hackage
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          curl -X PUT --fail --silent --show-error \
+            --header "Authorization: X-ApiKey ${HACKAGE_TOKEN}" \
+            --header "Content-Type: application/x-tar" \
+            --header "Content-Encoding: gzip" \
+            --data-binary "@dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" \
+            "https://hackage.haskell.org/package/nova-cache-${VERSION}/docs"
+        env:
+          HACKAGE_TOKEN: ${{ secrets.HACKAGE_TOKEN }}


### PR DESCRIPTION
0.8.0.0's Hackage page shows a build failure and no docs: Hackage's doc builder runs GHC 9.8 (base-4.19 installed, per [the build report](https://hackage.haskell.org/package/nova-cache-0.8.0.0/reports/2)) and the package's floor is `base >= 4.22` (GHC 9.14), so the builder cannot even resolve dependencies. Installability on the targeted toolchain is unaffected - the upload itself succeeded and the CI-green tag is what shipped. 0.7.0.0 got builder docs only because it predated the floor.

Maintainer-uploaded documentation is the standard remedy, and ours are already 100% coverage with zero warnings:

- **publish.yml** gains two steps after the sdist upload: `cabal haddock --haddock-for-hackage -f xz` (the flag so `NovaCache.Xz` documents too) and a curl PUT of the docs tarball to the package's docs endpoint with the same `HACKAGE_TOKEN`. Every future release ships its docs automatically.
- **docs.yml** (new, `workflow_dispatch` with a tag input) does the same for an already-published release - the backfill path for 0.8.0.0, and the redo path if ever needed.

After merge: dispatch `Docs` with `v0.8.0.0` and the package page gets its documentation.