### PR TITLE
CI: build the pinned ormolu from Hackage - the prebuilt binaries vanished

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,17 +55,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: haskell-actions/run-ormolu@v21
+
+      # Pinned to the version the repo is formatted with: formatting is
+      # not stable across ormolu releases, and a floating version would
+      # fail CI on untouched code when upstream ships one.  Upgrades
+      # bump this and the local binary together.
+      #
+      # Built from Hackage, not fetched prebuilt: run-ormolu@v21
+      # downloads binaries from mrkkrp/ormolu, and that repository
+      # vanished from GitHub on 2026-08-20, taking every prebuilt
+      # ormolu with it (the action then misreports the 404 as
+      # "unformatted files").  The Hackage build depends on nothing but
+      # the package index; the cached binary makes warm runs seconds.
+      # Undo into the action if prebuilt assets return to a stable home
+      # a released run-ormolu points at.
+      - name: Cache formatter binary
+        id: formatter-cache
+        uses: actions/cache@v5
         with:
-          # Pinned to the version the repo is formatted with: formatting
-          # is not stable across ormolu releases, and a floating version
-          # would fail CI on untouched code when upstream ships one.
-          # Upgrades bump this and the local binary together.
-          version: "0.9.0.0"
-          pattern: |
-            src/**/*.hs
-            test/**/*.hs
-            exe/**/*.hs
+          path: ~/.local/bin/ormolu
+          key: ormolu-0.9.0.0-${{ runner.os }}
+
+      - uses: haskell-actions/setup@v2
+        if: steps.formatter-cache.outputs.cache-hit != 'true'
+        with:
+          ghc-version: '9.14.1'
+          cabal-version: 'latest'
+
+      - name: Build ormolu 0.9.0.0 from Hackage
+        if: steps.formatter-cache.outputs.cache-hit != 'true'
+        run: cabal install ormolu-0.9.0.0 --install-method=copy --installdir="$HOME/.local/bin" --overwrite-policy=always
+
+      - name: Check formatting
+        run: git ls-files '*.hs' | xargs ormolu --mode check
 
   # ---------------------------------------------------------------------------
   # Build + Test (cross-platform matrix)


### PR DESCRIPTION
run-ormolu@v21 downloads its binary from mrkkrp/ormolu; that repository disappeared from GitHub today (the whole releases API 404s), and the action misreports the failed download as 'Ormolu detected unformatted files'. The tree is format-clean under the pinned 0.9.0.0 locally, and identical content passed this same job at 12:43Z; every run since 16:16Z fails in under a second with no diff - including reruns and the post-merge main runs.

The job now installs ormolu 0.9.0.0 from Hackage (depends on nothing but the package index) and caches the built binary; warm runs check in seconds. git ls-files '*.hs' replaces the glob patterns - the same tracked set today, and new Haskell files can never dodge the gate. Undo into the action if prebuilt assets return to a stable home a released run-ormolu points at.

Note: this PR's own Ormolu job pays the one-time cold Hackage build (~15-20 min, ghc-lib-parser); every later run restores the cached binary. Merge this first, then #38 rebases onto it.