### PR TITLE
CI: sublibrary docs tarball - ustar, no colon-named files, surfaced rejections

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,12 +45,13 @@ jobs:
           cabal haddock all --haddock-for-hackage
           # Same sublibrary graft as the publish workflow: cabal tars only
           # the main library's tree; Hackage serves sublibraries as
-          # subdirectories of the one release tree.  Undo the graft when
+          # subdirectories of the one release tree (re-tarred as ustar -
+          # Hackage's tar reader 400s GNU-format headers).  Undo the graft when
           # haskell/cabal#9577 lands (one tarball spanning every library).
           MAIN=$(find dist-newstyle -type d -name "nova-cache-${VERSION}-docs" -path "*/doc/html/*" -not -path "*/l/*")
           SUB=$(find dist-newstyle -type d -path "*/l/xz/*${VERSION}-docs/xz")
           cp -R "$SUB" "$MAIN/xz"
-          tar -czf "dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" -C "$(dirname "$MAIN")" "nova-cache-${VERSION}-docs"
+          tar --format=ustar -czf "dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" -C "$(dirname "$MAIN")" "nova-cache-${VERSION}-docs"
           tar -tzf "dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" | grep -q "xz/NovaCache-Xz.html"
 
       - name: Upload documentation to Hackage

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,6 +51,11 @@ jobs:
           MAIN=$(find dist-newstyle -type d -name "nova-cache-${VERSION}-docs" -path "*/doc/html/*" -not -path "*/l/*")
           SUB=$(find dist-newstyle -type d -path "*/l/xz/*${VERSION}-docs/xz")
           cp -R "$SUB" "$MAIN/xz"
+          # cabal names the sublibrary hoogle file nova-cache:xz.txt, and
+          # Hackage validates tarball paths as Windows-portable - a colon
+          # is an invalid character there and 400s the whole upload.  The
+          # hoogle database is not rendered documentation; drop it.
+          find "$MAIN" -name '*:*' -print -delete
           tar --format=ustar -czf "dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" -C "$(dirname "$MAIN")" "nova-cache-${VERSION}-docs"
           tar -tzf "dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" | grep -q "xz/NovaCache-Xz.html"
 
@@ -60,9 +65,14 @@ jobs:
         run: |
           VERSION="${{ inputs.tag }}"
           VERSION=${VERSION#v}
-          curl -X PUT --fail --silent --show-error \
+          # Not --fail: on rejection Hackage's response body names the
+          # offending entry, and losing it cost two blind retries once.
+          STATUS=$(curl -X PUT --silent --show-error --output /tmp/docs-response.txt --write-out "%{http_code}" \
             --header "Authorization: X-ApiKey ${HACKAGE_TOKEN}" \
             --header "Content-Type: application/x-tar" \
             --header "Content-Encoding: gzip" \
             --data-binary "@dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" \
-            "https://hackage.haskell.org/package/nova-cache-${VERSION}/docs"
+            "https://hackage.haskell.org/package/nova-cache-${VERSION}/docs")
+          cat /tmp/docs-response.txt
+          echo "docs upload HTTP ${STATUS}"
+          case "$STATUS" in 2??) ;; *) exit 22 ;; esac

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,14 +56,15 @@ jobs:
           # cabal writes each library's tree separately and tars only the
           # main one; Hackage serves one tree per release with sublibraries
           # as subdirectories (the layout cabal itself names: <docs>/xz).
-          # Graft the xz component in and re-tar.  The final grep fails the
+          # Graft the xz component in and re-tar as ustar - Hackage's tar
+          # reader 400s GNU-format headers, cabal's own tarballs are ustar.  The final grep fails the
           # job if a cabal layout change ever drops the module silently.
           # Undo the graft when haskell/cabal#9577 lands (one tarball
           # spanning every library).
           MAIN=$(find dist-newstyle -type d -name "nova-cache-${VERSION}-docs" -path "*/doc/html/*" -not -path "*/l/*")
           SUB=$(find dist-newstyle -type d -path "*/l/xz/*${VERSION}-docs/xz")
           cp -R "$SUB" "$MAIN/xz"
-          tar -czf "dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" -C "$(dirname "$MAIN")" "nova-cache-${VERSION}-docs"
+          tar --format=ustar -czf "dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" -C "$(dirname "$MAIN")" "nova-cache-${VERSION}-docs"
           tar -tzf "dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" | grep -q "xz/NovaCache-Xz.html"
       - name: Upload documentation to Hackage
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,16 +64,26 @@ jobs:
           MAIN=$(find dist-newstyle -type d -name "nova-cache-${VERSION}-docs" -path "*/doc/html/*" -not -path "*/l/*")
           SUB=$(find dist-newstyle -type d -path "*/l/xz/*${VERSION}-docs/xz")
           cp -R "$SUB" "$MAIN/xz"
+          # cabal names the sublibrary hoogle file nova-cache:xz.txt, and
+          # Hackage validates tarball paths as Windows-portable - a colon
+          # is an invalid character there and 400s the whole upload.  The
+          # hoogle database is not rendered documentation; drop it.
+          find "$MAIN" -name '*:*' -print -delete
           tar --format=ustar -czf "dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" -C "$(dirname "$MAIN")" "nova-cache-${VERSION}-docs"
           tar -tzf "dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" | grep -q "xz/NovaCache-Xz.html"
       - name: Upload documentation to Hackage
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          curl -X PUT --fail --silent --show-error \
+          # Not --fail: on rejection Hackage's response body names the
+          # offending entry, and losing it cost two blind retries once.
+          STATUS=$(curl -X PUT --silent --show-error --output /tmp/docs-response.txt --write-out "%{http_code}" \
             --header "Authorization: X-ApiKey ${HACKAGE_TOKEN}" \
             --header "Content-Type: application/x-tar" \
             --header "Content-Encoding: gzip" \
             --data-binary "@dist-newstyle/nova-cache-${VERSION}-docs.tar.gz" \
-            "https://hackage.haskell.org/package/nova-cache-${VERSION}/docs"
+            "https://hackage.haskell.org/package/nova-cache-${VERSION}/docs")
+          cat /tmp/docs-response.txt
+          echo "docs upload HTTP ${STATUS}"
+          case "$STATUS" in 2??) ;; *) exit 22 ;; esac
         env:
           HACKAGE_TOKEN: ${{ secrets.HACKAGE_TOKEN }}


### PR DESCRIPTION
Two release-blockers found by the live v0.9.0.0 docs uploads, one diagnosability fix:

- Hackage validates documentation tarball paths as Windows-portable: cabal names the sublibrary hoogle file nova-cache:xz.txt, and the colon 400s the whole upload. The graft drops colon-named files (hoogle databases are not rendered docs).
- The re-tar emits ustar - the portable layout cabal's own tarball writer uses - instead of GNU tar's default headers.
- The PUT no longer uses --fail: Hackage's rejection body names the offending entry, and losing it cost two blind retries.

Proven by dispatching the Docs workflow from this branch for v0.9.0.0 (the run linked below in comments once green).