### PR TITLE
Bzip2, Zstd: complete the public Haddock before 0.11 freezes it

### DIFF
--- a/src/NovaCache/Bzip2.hs
+++ b/src/NovaCache/Bzip2.hs
@@ -149,7 +149,9 @@ data Bzip2SourceState
 -- bounded pass.
 --
 -- Limit violations and malformed input are thrown as 'Bzip2Error'
--- from the pull.
+-- from the pull.  A pull that fails latches: every later pull
+-- rethrows the same exception, so a catch-and-retry consumer can
+-- never mistake an aborted transfer for a clean end of output.
 withBzip2Source :: Bzip2Limits -> IO ByteString -> (IO ByteString -> IO a) -> IO a
 withBzip2Source limits compressedSource consume = do
   opened <- newDecoder

--- a/src/NovaCache/Zstd.hs
+++ b/src/NovaCache/Zstd.hs
@@ -56,6 +56,7 @@ module NovaCache.Zstd
     compress,
     ZstdCompressionLevel,
     zstdCompressionLevel,
+    lowestCompressionLevel,
     maxCompressionLevel,
     defaultCompressionLevel,
     withZstdSource,


### PR DESCRIPTION
Pre-release verification's last two findings, both doc-only but immutable once the 0.11.0.0 docs reach Hackage: withBzip2Source's public Haddock omitted the latch contract (a failed pull rethrows forever - the exact guarantee the xz/zstd alignment bullet advertises), which lived only on an unexported type; and ZstdCompressionLevel's doc referenced lowestCompressionLevel without exporting it, leaving a dead identifier and an undocumented range floor in the rendered docs. Both fixed; all four suites green under -Werror. This is the last change before the v0.11.0.0 tag.