### PR TITLE
CI: gate the cbits shim - strict C99 and a sanitized run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Source must be ASCII-only
         run: |
-          if git grep -nP '[^\x00-\x7F]' -- '*.hs' '*.cabal' '*.md' '*.nix' '*.sh'; then
+          if git grep -nP '[^\x00-\x7F]' -- '*.hs' '*.c' '*.h' '*.cabal' '*.md' '*.nix' '*.sh'; then
             echo "Non-ASCII characters found above; keep the source ASCII-only (no smart quotes, em-dashes, or Unicode arrows)."
             exit 1
           fi
@@ -90,6 +90,48 @@ jobs:
         run: git ls-files '*.hs' | xargs ormolu --mode check
 
   # ---------------------------------------------------------------------------
+  # cbits/nova_bzip2.c is the only hand-written C in the tree, and the build
+  # compiles it with whatever warnings GHC's bootstrap toolchain defaults to
+  # - quiet enough that GNU extensions and implicit conversions never
+  # surface.  This job holds it to strict C99 instead.  Syntax-only, so
+  # nothing links or runs; declarations come from bzip2-clib's own bundled
+  # bzlib.h, fetched from Hackage rather than apt's libbz2-dev, so the lint
+  # reads the same header the build compiles against instead of a lookalike.
+  #
+  # -Wconversion -Wsign-conversion earn their place beyond the usual set:
+  # the shim's entire job is marshalling, and bz_stream's avail_in/avail_out
+  # are 32-bit unsigned while the Haskell side hands down Int.  Implicit
+  # narrowing there is the one defect class this file can plausibly carry,
+  # and -Wall -Wextra -pedantic does not diagnose it.
+  # ---------------------------------------------------------------------------
+
+  c99-lint:
+    name: C99 Strict
+    needs: [ascii]
+    runs-on: ubuntu-latest
+    env:
+      # Matches the floor of the bzip2-clib bound in nova-cache.cabal.
+      BZIP2_CLIB_VERSION: 1.0.8
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch the bundled bzlib.h the build compiles against
+        run: |
+          mkdir -p "$RUNNER_TEMP/clib-include"
+          curl -fsSL \
+            "https://hackage.haskell.org/package/bzip2-clib-$BZIP2_CLIB_VERSION/bzip2-clib-$BZIP2_CLIB_VERSION.tar.gz" \
+            | tar -xz --strip-components=2 -C "$RUNNER_TEMP/clib-include" \
+                "bzip2-clib-$BZIP2_CLIB_VERSION/cbits/bzlib.h"
+
+      - name: Compile C99 with strict warnings
+        run: |
+          for f in cbits/*.c; do
+            echo "Checking $f ..."
+            gcc -std=c99 -Wall -Wextra -pedantic -Wconversion -Wsign-conversion \
+                -Werror -fsyntax-only -Icbits -I"$RUNNER_TEMP/clib-include" "$f"
+          done
+
+  # ---------------------------------------------------------------------------
   # Build + Test (cross-platform matrix)
   # ---------------------------------------------------------------------------
 
@@ -139,7 +181,7 @@ jobs:
 
   cabal-check:
     name: Cabal Check
-    needs: [lint, format]
+    needs: [lint, format, c99-lint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -182,6 +224,83 @@ jobs:
           tar -xzf "$RUNNER_TEMP"/sdist/nova-cache-*.tar.gz -C "$RUNNER_TEMP"
           cd "$RUNNER_TEMP"/nova-cache-*/
           cabal build all -f server --enable-tests
+
+  # ---------------------------------------------------------------------------
+  # Exercise the cbits shim under ASan/UBSan (Linux-only).  The C99 job only
+  # compiles it; this one RUNS it, so a stray pointer or an overflow in the
+  # hand-written C fails CI instead of corrupting a decompressed NAR in
+  # production.  The bzip2 suite is the whole target: lib:bzip2 is the only
+  # component with c-sources, and the C behind xz and zstd belongs to
+  # dependencies this job deliberately leaves uninstrumented.  Linux is the
+  # host because GHC's mingw toolchain ships no sanitizer runtime and the
+  # shim is platform-independent, so one instrumented host is real coverage.
+  # ---------------------------------------------------------------------------
+
+  sanitizers:
+    name: ASan/UBSan
+    needs: [cabal-check]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: '9.14.1'
+          cabal-version: 'latest'
+
+      # Its own key, like sdist and deploy: this job builds neither the
+      # server flag nor the xz and zstd sublibraries, so its store holds a
+      # different set than the matrix build's.  Dependencies land in it
+      # unsanitized - the flags below are scoped to this package alone.
+      - name: Cache Cabal store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: cabal-sanitize-${{ hashFiles('nova-cache.cabal') }}
+          restore-keys: cabal-sanitize-
+
+      # Scoped through cabal.project.local so only this package's cbits
+      # compile instrumented and only its test executable links the
+      # sanitizer runtimes; a command-line --ghc-options would rebuild every
+      # dependency instrumented too.  -fno-sanitize-recover makes each UBSan
+      # report fatal rather than a log line CI would scroll past.  No
+      # -Werror here: the warnings gate is the build matrix, and this job's
+      # signal is runtime findings.
+      - name: Scope sanitizer flags to this package
+        run: |
+          {
+            echo "package nova-cache"
+            echo "  ghc-options: -optc-fsanitize=address,undefined -optc-fno-sanitize-recover=all -optl-fsanitize=address,undefined"
+          } > cabal.project.local
+
+      - name: Build with instrumented cbits
+        run: cabal build nova-cache-bzip2-test
+
+      # cabal reuses an existing C object across a ghc-options change, so a
+      # warm build tree can link an uninstrumented shim and leave this job
+      # green having tested nothing.  Fail loudly instead of silently.
+      - name: Confirm the shim is instrumented
+        run: |
+          obj=$(find dist-newstyle -name 'nova_bzip2.o' -print -quit)
+          if [ -z "$obj" ]; then
+            echo "nova_bzip2.o not found; the bzip2 sublibrary did not build"
+            exit 1
+          fi
+          if ! nm "$obj" | grep -q '__asan'; then
+            echo "$obj carries no ASan instrumentation; the flags did not reach the C compile"
+            exit 1
+          fi
+
+      # detect_leaks=0: LeakSanitizer would report the GHC RTS's
+      # process-lifetime allocations, plus any bz_stream whose ForeignPtr
+      # finalizer the RTS never ran before exit - neither is a shim defect.
+      # The stream's own teardown path is exercised by the suite itself.
+      - name: Test under sanitizers
+        env:
+          ASAN_OPTIONS: detect_leaks=0
+          UBSAN_OPTIONS: print_stacktrace=1
+        run: cabal test nova-cache-bzip2-test
 
   # ---------------------------------------------------------------------------
   # Deploy (main branch only): build on the hosted arm64 image, ship the


### PR DESCRIPTION
`cbits/nova_bzip2.c` has been in the tree and on Hackage since 0.11.0.0 with nothing checking it. The build compiles it at whatever warning level GHC's bootstrap toolchain defaults to, and no job ever ran it under a sanitizer. nova-nix has held its own cbits to both gates since it grew any; this is the same pair, ported.

## C99 Strict

Compiles every `cbits/*.c` with `-std=c99 -Wall -Wextra -pedantic -Werror`, syntax-only so nothing links. Two departures from nova-nix's otherwise identical job, both because this shim is pure marshalling across a signedness boundary.

`-Wconversion -Wsign-conversion` are added. `bz_stream`'s `avail_in` and `avail_out` are 32-bit unsigned while the Haskell side hands down `Int`, so implicit narrowing is the one defect class this file can plausibly carry, and the usual set does not diagnose it. Demonstrated rather than assumed:

```
$ cc -std=c99 -Wall -Wextra -pedantic -Werror -fsyntax-only ...   # negative int -> avail_in
  (silent)
$ cc -std=c99 -Wall -Wextra -pedantic -Wconversion -Wsign-conversion -Werror ...
  error: implicit conversion changes signedness: 'int' to 'unsigned int'
```

The shim is already clean under both sets, so the added flags cost nothing today and close the class going forward.

The declarations come from bzip2-clib's own `bzlib.h`, pulled from Hackage, rather than apt's `libbz2-dev`. The build compiles against the bundled header, so the lint should read that same header rather than a lookalike that happens to share upstream 1.0.8's prototypes. It also drops an apt install from the job.

## ASan/UBSan

Runs the bzip2 suite with the shim instrumented. `lib:bzip2` is the only component with `c-sources`; the C behind xz and zstd belongs to dependencies this job deliberately leaves uninstrumented. Linux only, since GHC's mingw toolchain ships no sanitizer runtime and the shim is platform-independent, so one instrumented host is real coverage.

Flags are scoped through `cabal.project.local` so only this package compiles instrumented; a command-line `--ghc-options` would rebuild every dependency that way too.

Between the build and the test sits a check that the emitted object actually carries `__asan`. cabal reuses an existing C object across a `ghc-options` change, so a warm tree can link an uninstrumented shim and leave the job green having tested nothing. This is not hypothetical, it fired on the first local run against a warm tree and passed after a cold one.

## Verification

Run locally on aarch64-osx before pushing:

- `cabal build --enable-tests --ghc-options="-Werror" all` clean
- `cabal test all` passing
- shim clean under `-Wall -Wextra -pedantic` and under `-Wconversion -Wsign-conversion`
- instrumentation check fails on a warm tree, passes on a cold one
- **all 15 bzip2 tests pass under ASan/UBSan**, including the hostile trio, the bound cases, and the failure-latch cases

The ASCII gate also widens to `*.c` and `*.h`, which it should have covered from the moment the tree grew C.