### PR TITLE
NAR.Stream: unhook the possessive from the Haddock link

### DIFF
--- a/src/NovaCache/NAR/Stream.hs
+++ b/src/NovaCache/NAR/Stream.hs
@@ -169,8 +169,8 @@ narStream :: NarStep
 narStream = narStreamBounded maxWireStringBytes
 
 -- | The largest structural-string bound 'narStreamBounded' honors:
--- 'Int''s ceiling less alignment headroom, so a payload at the bound
--- still fits 'Int' together with its padding.
+-- the ceiling of 'Int' less alignment headroom, so a payload at the
+-- bound still fits 'Int' together with its padding.
 structuralBoundCeiling :: Word64
 structuralBoundCeiling =
   fromIntegral (maxBound :: Int) - fromIntegral (narAlignment - 1)


### PR DESCRIPTION
Haddock parses the docstring's `'Int''s` as a reference to an identifier named `Int'`, which does not exist, so every docs build warns "'Int'' is out of scope" (visible in the Docs workflow log). Rephrased to "the ceiling of 'Int'" so the reference is `Int` and the possessive is gone. Comment only; the rendered sentence is equivalent.

Gates: ormolu 0.9.0.0 check clean, hlint clean, cabal haddock nova-cache now warning-free.