### PR TITLE
Docs: the xz migration's two stale comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,10 @@ jobs:
 
       # all + -f server + --enable-tests so the server executable, the xz
       # sublibrary, and the test suites hit the same -Werror bar as the
-      # library on every OS.  No liblzma setup: lzma-static bundles the C
-      # sources.  The sdist job builds the same set from the tarball.
+      # library on every OS.  No liblzma setup: cabal.project pins the xz
+      # package to its bundled xz-clib (constraints: xz -system-xz), so
+      # no runner needs the system library.  The sdist job builds the
+      # same set from the tarball.
       - name: Build
         run: cabal build all -f server --enable-tests --ghc-options="-Werror"
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ cabal build
 cabal test
 ```
 
-Optional extras: `--flag server` builds the cache server, and the public `nova-cache:xz`, `nova-cache:bzip2`, and `nova-cache:zstandard` sublibraries carry the bounded codecs (liblzma, libbz2, and libzstd are bundled - no system libraries needed) - consumers depend on them with `build-depends: nova-cache:xz` and the like. Requires GHC 9.14+ and cabal-install 3.10+.
+Optional extras: `--flag server` builds the cache server, and the public `nova-cache:xz`, `nova-cache:bzip2`, and `nova-cache:zstandard` sublibraries carry the bounded codecs - consumers depend on them with `build-depends: nova-cache:xz` and the like. libbz2 and libzstd are bundled; liblzma comes from the `xz` package, which prefers a pkg-config system liblzma and falls back to its bundled `xz-clib` (pin `constraints: xz -system-xz` to force the bundled copy, as this repo's cabal.project does). Requires GHC 9.14+ and cabal-install 3.10+.
 
 ---
 


### PR DESCRIPTION
Two comments still described the lzma-static dependency after #66 migrated to xz. The ci.yml build comment credited lzma-static with bundling the C sources; the bundling actually comes from cabal.project pinning constraints: xz -system-xz. The README claimed all three codec C libraries are unconditionally bundled with no system libraries needed; that is true of libbz2 and libzstd, while liblzma prefers a pkg-config system copy unless the constraint forces the bundled xz-clib. Both now state the real mechanism, including what a consumer without the constraint gets. Comment and prose only, no code.