### PR TITLE
NAR: normalise a symlink target's separators on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **A symlink target with a separator serialises to its POSIX spelling on every platform.** Windows stores a symlink's reparse point with backslashes, so a target written `bin/tool` reads back `bin\tool`, and `getSymbolicLinkTarget` returned that verbatim into the NAR. NAR targets are host-independent byte strings in the POSIX spelling, so the archive of the same logical tree diverged between Windows and POSIX, and an unpack-then-recheck round-trip failed its on-disk hash comparison on Windows for any symlink whose target had more than one component. Both producers now normalise the separator to `/` when reading a target on Windows, where a backslash is only ever a separator and encodes as the single byte `0x5C` that no multi-byte UTF-8 sequence contains, so the byte-level replacement is exact. POSIX is untouched, where a backslash is a legitimate filename byte.
+
 ## 0.11.1.0 - 2026-08-26
 
 - **The default executable answer on POSIX is the file's own owner-execute bit, matching upstream's dump.** `defaultExecBitResolver` (and so both producers before any custom resolver) read `getPermissions`, which answers from `access(2)`: what the calling process may do. Root read any execute bit as executable, ACLs counted, and a file the caller does not own answered by the caller's groups; upstream reads `st_mode & S_IXUSR`, a property of the file alone, and the flag lands in NAR bytes, so the divergence moved a hash exactly where the caller was unusual. The POSIX default now reads the mode bit directly; Windows keeps the extension answer, which is all the platform has.

--- a/src/NovaCache/NAR.hs
+++ b/src/NovaCache/NAR.hs
@@ -364,7 +364,7 @@ walkPath :: SerialiseOptions -> OsPath -> IO NarEntry
 walkPath opts path = do
   isSym <- pathIsSymbolicLink path
   if isSym
-    then NarSymlink <$> (osPathBytes =<< getSymbolicLinkTarget path)
+    then NarSymlink <$> (symlinkTargetBytes =<< getSymbolicLinkTarget path)
     else do
       isDir <- doesDirectoryExist path
       if isDir
@@ -492,6 +492,26 @@ osPathBytes path = case OP.decodeWith latin1 latin1 path of
     -- point N, and Char8 re-truncation above inverts it exactly - but
     -- surfacing the impossible beats hiding it.
     fail ("serialiseFromPath: undecodable name: " ++ show err)
+#endif
+
+-- | A symlink target's NAR bytes.  Identical to 'osPathBytes' for a name,
+-- except that on Windows the separator is normalised to @\/@: Windows
+-- stores a reparse point with backslashes, so a target written @bin\/tool@
+-- reads back @bin\\tool@, and a NAR target is the POSIX spelling on every
+-- platform so the archive stays host-independent.  A backslash is only
+-- ever a separator on Windows, never a filename byte, and it encodes as
+-- the single byte @0x5C@ that no multi-byte UTF-8 sequence contains, so
+-- the byte-level replacement is exact.  On POSIX a backslash is a
+-- legitimate filename byte and is left untouched.
+symlinkTargetBytes :: OsPath -> IO ByteString
+#ifdef mingw32_HOST_OS
+symlinkTargetBytes path = BS.map normalizeSeparator <$> osPathBytes path
+  where
+    normalizeSeparator b = if b == backslashByte then forwardSlashByte else b
+    backslashByte = 0x5C
+    forwardSlashByte = 0x2F
+#else
+symlinkTargetBytes = osPathBytes
 #endif
 
 -- ---------------------------------------------------------------------------
@@ -633,7 +653,7 @@ planNode opts path = do
   isSym <- pathIsSymbolicLink path
   if isSym
     then do
-      target <- osPathBytes =<< getSymbolicLinkTarget path
+      target <- symlinkTargetBytes =<< getSymbolicLinkTarget path
       pure [PieceBytes (buildNode (NarSymlink target))]
     else do
       isDir <- doesDirectoryExist path

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -31,7 +31,7 @@ import qualified NovaCache.Signing as Signing
 import qualified NovaCache.Store as Store
 import qualified NovaCache.StorePath as StorePath
 import qualified NovaCache.Validate as Validate
-import System.Directory (createDirectory, getPermissions, getTemporaryDirectory, listDirectory, removeDirectoryRecursive, setOwnerExecutable, setPermissions)
+import System.Directory (createDirectory, createFileLink, getPermissions, getTemporaryDirectory, listDirectory, removeDirectoryRecursive, setOwnerExecutable, setPermissions)
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (hFlush, stdout)
 import qualified System.Info
@@ -573,6 +573,27 @@ testNAR =
             expected
             (sort (map baseName planned))
         pure (walkOk && planOk),
+      -- A symlink target with a separator serialises to the POSIX
+      -- spelling on every platform (nova-nix #112): Windows stores a
+      -- reparse point with backslashes, so a target written bin/tool
+      -- reads back bin\tool, and an unpack-then-recheck round-trip
+      -- diverges from the archive unless the NAR boundary normalises
+      -- it.  Both producers must agree with the forward-slash form.
+      -- Guarded on symlink privilege, which a Windows runner without
+      -- developer mode lacks.
+      test "a separator-bearing symlink target serialises with forward slashes" $ do
+        dir <- caseHackFixture "nova-cache-test-symlinksep"
+        created <- try (createFileLink "bin/tool" (dir <> "/link")) :: IO (Either SomeException ())
+        case created of
+          Left _ -> removeDirectoryRecursive dir >> pure True
+          Right () -> do
+            let expectedEntry = NAR.NarDirectory [("link", NAR.NarSymlink "bin/tool")]
+            eager <- NAR.serialiseFromPathWith NAR.CaseHackDisabled dir
+            streamed <- NAR.withNarSource NAR.CaseHackDisabled dir drainSource
+            removeDirectoryRecursive dir
+            eagerOk <- assertEqual "eager target spelling" expectedEntry eager
+            streamOk <- assertEqual "streamed target spelling" (NAR.serialise expectedEntry) streamed
+            pure (eagerOk && streamOk),
       -- The walk's boundary encoding: a Unicode disk name enters the
       -- archive as its UTF-8 bytes on every platform.
       test "serialiseFromPath encodes a Unicode disk name as UTF-8" $ do


### PR DESCRIPTION
Fixes the disk boundary behind nova-nix #112. getSymbolicLinkTarget returns a Windows reparse point with backslashes, so a symlink target written `bin/tool` reads back `bin\tool`, and osPathBytes carried that into the NAR verbatim. A NAR target is a host-independent byte string in the POSIX (forward-slash) spelling, so the archive of one logical tree diverged between Windows and POSIX, and nova-nix's unpack-then-recheck round-trip failed its on-disk hash comparison on Windows for any symlink whose target had more than one component (a systematic, silent-corruption-proof hard substitution failure there).

Both producers, the eager walk (serialiseFromPath) and the streaming source (withNarSource), now read the target through a new symlinkTargetBytes helper that on Windows maps the separator byte to forward slash. The replacement is byte-exact and safe: a backslash is only ever a separator on Windows (never a filename byte), and it encodes as the single byte 0x5C that no multi-byte UTF-8 sequence contains. POSIX keeps osPathBytes unchanged, where a backslash is a legitimate filename byte.

The new test round-trips a bin/tool target through both producers and asserts the forward-slash spelling. It is a POSIX no-op (the target is stored and read verbatim there, so it also guards against a future regression) and the real proof on the windows-latest matrix leg, guarded on symlink-creation privilege since a runner without developer mode lacks it.

This ships in the next nova-cache release; nova-nix then bumps its floor and flips the platform-split symlink guard the streaming-substitution suite (#110) left in place.