### PR TITLE
Release 0.11.1.1: symlink target separator normalisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.11.1.1 - 2026-08-26
 
 - **A symlink target with a separator serialises to its POSIX spelling on every platform.** Windows stores a symlink's reparse point with backslashes, so a target written `bin/tool` reads back `bin\tool`, and `getSymbolicLinkTarget` returned that verbatim into the NAR. NAR targets are host-independent byte strings in the POSIX spelling, so the archive of the same logical tree diverged between Windows and POSIX, and an unpack-then-recheck round-trip failed its on-disk hash comparison on Windows for any symlink whose target had more than one component. Both producers now normalise the separator to `/` when reading a target on Windows, where a backslash is only ever a separator and encodes as the single byte `0x5C` that no multi-byte UTF-8 sequence contains, so the byte-level replacement is exact. POSIX is untouched, where a backslash is a legitimate filename byte.
 

--- a/nova-cache.cabal
+++ b/nova-cache.cabal
@@ -4,7 +4,7 @@ cabal-version:      3.4
 -- 3.0 an in-package component name shadowed its external namesake
 -- (the hazard the zstandard library's name dodges, documented there).
 name:               nova-cache
-version:            0.11.1.0
+version:            0.11.1.1
 synopsis:           Pure-first Nix binary cache protocol library
 description:
   A pure-first library implementing the Nix binary cache protocol -


### PR DESCRIPTION
Release prep for the Windows symlink-target fix (#70). Dates the changelog's top section to 0.11.1.1 and bumps the version, both required before the publish workflow will upload (it refuses while the top section is still ## Unreleased, and the version must match the tag).

Patch bump per PVP: the fix adds no exported API (symlinkTargetBytes is an internal helper), so no downstream bound has to move. nova-nix will raise its floor to >= 0.11.1.1 to require the fix and then close its #112.

After this merges, tag v0.11.1.1 to trigger the Hackage publish.